### PR TITLE
New config var: CONFIG_NAME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
 	rm -rf /var/lib/apt/lists/*
 
 ENV DATA_DIR="/urbanterror"
+ENV CONFIG_NAME="server.cfg"
 ENV DL_URL="http://www.urbanterror.info/downloads/software/urt/43/UrbanTerror43_ded.tar.gz"
 ENV GAME_V="1"
 ENV DL_LOCATION="1"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Urban Terror can be described as a Hollywood tactical shooter; somewhat realism 
 | Name | Value | Example |
 | --- | --- | --- |
 | DATA_DIR | Folder for configfiles and the application | /urbanterror |
+| CONFIG_NAME | Specify a custom server configuration file name | server-ctf.cfg |
 | START_PARAMS | Enter you extra startup parameters if needed | *empty* |
 | CHECK_FOR_UPDATES | Set to 'true' (without quotes) to search for updates on every start/restart otherwise leave empty | true |
 | UID | User Identifier | 99 |

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -30,15 +30,19 @@ else
 fi
 
 echo "---Preparing Server---"
-if [ ! -f ${DATA_DIR}/q3ut4/server.cfg ]; then
-    echo "---'server.cfg' not found, creating...---"
-    cp ${DATA_DIR}/q3ut4/server_example.cfg ${DATA_DIR}/q3ut4/server.cfg
-    sed -i "/set  sv_hostname                       \"New Unnamed Server\"/c\set  sv_hostname                       \"Docker Server\"" ${DATA_DIR}/q3ut4/server.cfg
+if [ ! -z "${CONFIG_NAME}" ] && [ -f ${DATA_DIR}/q3ut4/${CONFIG_NAME} ]; then
+    echo "---Found custom server configuration file: ${CONFIG_NAME} ---"
 else
-    echo "---'server.cfg' found, continuing!---"
+    if [ ! -f ${DATA_DIR}/q3ut4/server.cfg ]; then
+        echo "---'server.cfg' not found, creating...---"
+        cp ${DATA_DIR}/q3ut4/server_example.cfg ${DATA_DIR}/q3ut4/server.cfg
+        sed -i "/set  sv_hostname                       \"New Unnamed Server\"/c\set  sv_hostname                       \"Docker Server\"" ${DATA_DIR}/q3ut4/server.cfg
+    else
+        echo "---'server.cfg' found, continuing!---"
+    fi
 fi
 chmod -R ${DATA_PERM} ${DATA_DIR}
 
 echo "---Starting Urban Terror---"
 cd ${DATA_DIR}
-${DATA_DIR}/Quake3-UrT-Ded.x86_64 +set net_port ${GAME_PORT} +set fs_homepath ${DATA_DIR} +exec server.cfg ${START_PARAMS}
+${DATA_DIR}/Quake3-UrT-Ded.x86_64 +set net_port ${GAME_PORT} +set fs_homepath ${DATA_DIR} +exec ${CONFIG_NAME} ${START_PARAMS}

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -30,8 +30,14 @@ else
 fi
 
 echo "---Preparing Server---"
-if [ ! -z "${CONFIG_NAME}" ] && [ -f ${DATA_DIR}/q3ut4/${CONFIG_NAME} ]; then
+if [ ! -z "${CONFIG_NAME}" ]; then
     echo "---Found custom server configuration file: ${CONFIG_NAME} ---"
+    if [ ! -f "${DATA_DIR}/q3ut4/${CONFIG_NAME}" ]; then
+      echo "--------------------------------------------------"
+      echo "---ERROR! The file ${CONFIG_NAME} does not exist---"
+      echo "--------------------------------------------------"
+      exit 1
+    fi
 else
     if [ ! -f ${DATA_DIR}/q3ut4/server.cfg ]; then
         echo "---'server.cfg' not found, creating...---"


### PR DESCRIPTION
This PR allows setting a custom configuration file name to be able to run multiple servers from the same data files. 

Currently, this image will always look for a hard coded server config file name called `server.cfg`, which makes it not possible to run multiple containers  to run multiple servers (ie. CTF, TS, etc) using the same game files.  The only way to do it is by having a copy of the game files per each server you want to run, each one with the desired server configuration named `server.cfg`.

With this modification, a variable called `CONFIG_NAME` can be setup with a custom configuration file name (ie. `server-ctf.cfg`), allowing to reuse the same game installation to launch multiple servers (containers). 

The `CONFIG_NAME` variable has a default value of `server.cfg`, so this PR will not break any current installation.